### PR TITLE
Add smart indentation

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -475,6 +475,10 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
             startPosition.columnIndex += indentString.length * indentCount;
             endPosition.columnIndex += indentString.length * indentCount;
 
+            if (previousLineRemaining.length == 0) { // Automatically clear lines that contain indentation only
+                allLines[startPosition.lineIndex - 1] = "";
+            }
+
             inter.setCode(allLines.join("\n"));
 
             inter.setPrimarySelection(new Selection(startPosition.toIndex(inter.getCode()), endPosition.toIndex(inter.getCode())));

--- a/src/editor.js
+++ b/src/editor.js
@@ -342,6 +342,10 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
 
     input.on("keydown", function(event) {
         if (["Tab", "Backspace"].includes(event.code)) {
+            if (props.noSmartIndentation) {
+                return;
+            }
+
             if (event.code == "Tab" && nextTabMovesFocus) {
                 // TODO: Add checks to see if gShell Switch Navigation causes this event
 
@@ -450,6 +454,10 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
 
     input.on("keyup", function(event) {
         if (event.code == "Enter" && !event.shiftKey) { // Indent subsequent lines
+            if (props.noSmartIndentation) {
+                return;
+            }
+
             var startPosition = inter.getPositionVector(inter.getPrimarySelection().start);
             var endPosition = inter.getPositionVector(inter.getPrimarySelection().end);
             var allLines = inter.getCode().split("\n");

--- a/src/editor.js
+++ b/src/editor.js
@@ -86,6 +86,10 @@ export class PositionVector {
         // Add 1 for each line to count newlines; subtract 1 to ignore final newline
         return selectedLines.map((line) => line.length + 1).reduce((accumulator, value) => accumulator + value, 0) - 1;
     }
+
+    clone() {
+        return new this.constructor(this.lineIndex, this.columnIndex);
+    }
 }
 
 export var CodeLine = astronaut.component("CodeLine", function(props, children, inter) {
@@ -155,6 +159,7 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
     var lineCache = {};
     var lastActivity = Date.now();
     var parserClass = parsers.registeredParsers[props.language] || parsers.Parser;
+    var indentString = props.indentString || "    ";
 
     inter.getPrimarySelection = function() {
         return new Selection(input.get().selectionStart, input.get().selectionEnd);
@@ -333,6 +338,125 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
 
         inter.render();
     };
+
+    input.on("keydown", function(event) {
+        if (["Tab", "Backspace"].includes(event.code)) {
+            var startPosition = inter.getPositionVector(inter.getPrimarySelection().start);
+            var endPosition = inter.getPositionVector(inter.getPrimarySelection().end);
+            var allLines = inter.getCode().split("\n");
+            var selectedLines = allLines.slice(startPosition.lineIndex, endPosition.lineIndex + 1);
+            var newStartPosition = startPosition.clone();
+            var newEndPosition = endPosition.clone();
+
+            if (event.code == "Tab" && !event.shiftKey && selectedLines.length == 1) { // Add tab to current line at selection
+                var distanceToNextTabStop = indentString.length - (selectedLines[0].substring(0, startPosition.columnIndex).length % indentString.length);
+
+                event.preventDefault();
+
+                selectedLines[0] = selectedLines[0].substring(0, startPosition.columnIndex) + indentString.substring(0, distanceToNextTabStop) + selectedLines[0].substring(endPosition.columnIndex);
+
+                newStartPosition.columnIndex += distanceToNextTabStop;
+                newEndPosition.columnIndex += distanceToNextTabStop - (endPosition.columnIndex - startPosition.columnIndex);
+            }
+
+            if (event.code == "Tab" && !event.shiftKey && selectedLines.length != 1) { // Indent all selected lines if more than one line is selected
+                event.preventDefault();
+
+                newStartPosition.columnIndex += indentString.length;
+                newEndPosition.columnIndex += indentString.length;
+
+                selectedLines.forEach(function(line, i) {
+                    selectedLines[i] = indentString + line;
+                });
+            }
+
+            if (event.code == "Tab" && event.shiftKey) { // Dedent all selected lines
+                event.preventDefault();
+
+                selectedLines.forEach(function(line, i) {
+                    var newLineStart = 0;
+                    var startWhitespaceMatch = line.match(/^\s+/);
+
+                    if (line.startsWith(indentString)) {
+                        newLineStart = indentString.length;
+                    } else if (
+                        indentString.match(/^\s+$/) && // Indent is whitespace only
+                        startWhitespaceMatch && // Some whitespace matches at start
+                        startWhitespaceMatch[0].length < indentString.length // Whitespace at start is shorter than indent string
+                    ) {
+                        newLineStart = startWhitespaceMatch[0].length;
+                    }
+
+                    if (newLineStart == 0) {
+                        return;
+                    }
+
+                    selectedLines[i] = line.substring(newLineStart);
+
+                    if (i == 0) {
+                        newStartPosition.columnIndex -= newLineStart;
+                    }
+
+                    if (i == selectedLines.length - 1) {
+                        newEndPosition.columnIndex -= newLineStart;
+                    }
+                });
+            }
+
+            if (event.code == "Backspace" && !event.shiftKey && selectedLines.length == 1) { // Dedent line if backspace from end of indent
+                var line = selectedLines[0].substring(0, endPosition.columnIndex);
+                var lineRemaining = line;
+                var indentCount = 0;
+
+                while (lineRemaining.startsWith(indentString)) {
+                    lineRemaining = lineRemaining.substring(indentString.length);
+                    indentCount++;
+                }
+
+                if (indentCount > 0 && endPosition.columnIndex <= indentString.length * indentCount) {
+                    event.preventDefault();
+
+                    selectedLines[0] = selectedLines[0].substring(indentString.length);
+
+                    newStartPosition.columnIndex -= indentString.length;
+                    newEndPosition.columnIndex -= indentString.length;
+                }
+            }
+
+            selectedLines.forEach(function(newLine, i) {
+                allLines[startPosition.lineIndex + i] = newLine;
+            });
+
+            inter.setCode(allLines.join("\n"));
+
+            inter.setPrimarySelection(new Selection(newStartPosition.toIndex(inter.getCode()), newEndPosition.toIndex(inter.getCode())));
+        }
+    });
+
+    input.on("keyup", function(event) {
+        if (event.code == "Enter" && !event.shiftKey) { // Indent subsequent lines
+            var startPosition = inter.getPositionVector(inter.getPrimarySelection().start);
+            var endPosition = inter.getPositionVector(inter.getPrimarySelection().end);
+            var allLines = inter.getCode().split("\n");
+            var previousLine = allLines[startPosition.lineIndex - 1];
+            var previousLineRemaining = previousLine;
+            var indentCount = 0;
+
+            while (previousLineRemaining.startsWith(indentString)) {
+                previousLineRemaining = previousLineRemaining.substring(indentString.length);
+                indentCount++;
+            }
+
+            allLines[startPosition.lineIndex] = indentString.repeat(indentCount) + allLines[startPosition.lineIndex];
+
+            startPosition.columnIndex += indentString.length * indentCount;
+            endPosition.columnIndex += indentString.length * indentCount;
+
+            inter.setCode(allLines.join("\n"));
+
+            inter.setPrimarySelection(new Selection(startPosition.toIndex(inter.getCode()), endPosition.toIndex(inter.getCode())));
+        }
+    })
 
     input.on("input", function() {
         var previousState = JSON.stringify(lines[inter.getPositionVector().lineIndex]?.inter.getParserInstance().state);

--- a/src/editor.js
+++ b/src/editor.js
@@ -160,6 +160,7 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
     var lastActivity = Date.now();
     var parserClass = parsers.registeredParsers[props.language] || parsers.Parser;
     var indentString = props.indentString || "    ";
+    var nextTabMovesFocus = false;
 
     inter.getPrimarySelection = function() {
         return new Selection(input.get().selectionStart, input.get().selectionEnd);
@@ -341,6 +342,14 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
 
     input.on("keydown", function(event) {
         if (["Tab", "Backspace"].includes(event.code)) {
+            if (event.code == "Tab" && nextTabMovesFocus) {
+                // TODO: Add checks to see if gShell Switch Navigation causes this event
+
+                nextTabMovesFocus = false;
+
+                return;
+            }
+
             var startPosition = inter.getPositionVector(inter.getPrimarySelection().start);
             var endPosition = inter.getPositionVector(inter.getPrimarySelection().end);
             var allLines = inter.getCode().split("\n");
@@ -430,6 +439,12 @@ export var CodeEditor = astronaut.component("CodeEditor", function(props, childr
             inter.setCode(allLines.join("\n"));
 
             inter.setPrimarySelection(new Selection(newStartPosition.toIndex(inter.getCode()), newEndPosition.toIndex(inter.getCode())));
+        }
+
+        nextTabMovesFocus = false;
+
+        if (event.code == "Escape") {
+            nextTabMovesFocus = true;
         }
     });
 


### PR DESCRIPTION
This PR adds smart indentation, which allows the <kbd>Tab</kbd> key to be used to indent code, and <kbd>Shift</kbd> + <kbd>Tab</kbd> to dedent code. Indents are automatically created when the <kbd>Enter</kbd> key is pressed.

## Task list
- [x] <kbd>Tab</kbd> indents selected code
- [x] <kbd>Shift</kbd> dedents selected code
- [x] <kbd>Enter</kbd> adds indentations to next line based on previous line's indentation
- [x] <kbd>Backspace</kbd> dedents the current line of code if done at the start of the line, just after the indentation
- [x] Accessible method added to unfocus editor using keyboard
- [ ] ~~Responds to bracket pairs~~ — out of scope for now as this would be implemented as part of a 'smart bracket closing' feature where closing brackets are automatically added when opening ones are typed
- [x] Clear lines that contain indentation only when new lines are created below them